### PR TITLE
a few perf improvments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@company-z/ethereum-multicall",
-  "version": "2.15.22",
+  "version": "2.16.0",
   "description": "Multicall allows multiple smart contract constant function calls to be grouped into a single call and the results aggregated into a single result",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -24,6 +24,7 @@
   "dependencies": {
     "@ethersproject/providers": "5.8.0",
     "ethers": "5.8.0",
+    "lru-cache": "^11.2.5",
     "undici": "^6.6.2"
   },
   "devDependencies": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,29 @@
 export class Utils {
   /**
-   * Deep clone a object
+   * Deep clone an object
+   * Uses structuredClone when available (10x faster than JSON.parse/stringify)
    * @param object The object
    */
   public static deepClone<T>(object: T): T {
+    // For primitives, just return the value directly
+    if (object === null || typeof object !== 'object') {
+      return object;
+    }
+    
+    // Use structuredClone if available (Node 17+, modern browsers)
+    if (typeof structuredClone === 'function') {
+      return structuredClone(object);
+    }
+    
+    // Fallback to JSON method for older environments
     return JSON.parse(JSON.stringify(object)) as T;
+  }
+
+  /**
+   * Shallow clone an object (much faster for simple objects)
+   * @param object The object
+   */
+  public static shallowClone<T extends object>(object: T): T {
+    return { ...object } as T;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2015",
     "lib": ["es6", "dom", "es2016", "es2017"],
     "module": "esnext",
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,7 @@ __metadata:
     "@types/node": ^18.0.0
     ethereum-abi-types-generator: ^1.0.6
     ethers: 5.8.0
+    lru-cache: ^11.2.5
     typescript: ^4.1.3
     undici: ^6.6.2
   languageName: unknown
@@ -1231,6 +1232,13 @@ __metadata:
   dependencies:
     p-locate: ^4.1.0
   checksum: 83e51725e67517287d73e1ded92b28602e3ae5580b301fe54bfb76c0c723e3f285b19252e375712316774cf52006cb236aed5704692c32db0d5d089b69696e30
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.2.5":
+  version: 11.2.5
+  resolution: "lru-cache@npm:11.2.5"
+  checksum: b3cd18066c81e0540429507036e0a37f860325348f6a85376ed71196e5b893668af410849574c5fb49110bc0afff76b4f87646cb93b2482a315c9e7b8435630f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core request/response building in `Multicall` (ABI encoding/decoding and result shaping) and adds new caching and batching paths, which could subtly alter call ordering/mapping or memory usage under load.
> 
> **Overview**
> Improves multicall throughput by **removing most deep-cloning** in result construction (including returning the original `ContractCallContext` by reference) and by switching aggregation mapping to `Map`-based O(1) lookups.
> 
> Adds **LRU caching** (`lru-cache`) for `ethers.Interface` instances and ABI output-type lookups to avoid repeated ABI parsing, and introduces/extends performance features for custom JSON-RPC: optional `undici` pooling, cached provider/network ID, and support for splitting large call sets into **parallel batches**. Also updates `Utils.deepClone` to prefer `structuredClone` and bumps TS target to `ES2015` (package version `2.16.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e14484d3786432f49b8e487f6a6983cb2bba42ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->