### PR TITLE
Derek/index bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@company-z/ethereum-multicall",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Multicall allows multiple smart contract constant function calls to be grouped into a single call and the results aggregated into a single result",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@company-z/ethereum-multicall",
-  "version": "2.16.2",
+  "version": "2.17.0",
   "description": "Multicall allows multiple smart contract constant function calls to be grouped into a single call and the results aggregated into a single result",
   "main": "dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -238,15 +238,31 @@ export class Multicall {
 
         if (outputTypes && outputTypes.length > 0) {
           try {
-            const decodedReturnValues = defaultAbiCoder.decode(
-              // tslint:disable-next-line: no-any
-              outputTypes as any,
-              this.getReturnDataFromResult(methodContext.result)
-            );
+            // getReturnDataFromResult returns hex bytes string (typed as any[] but actually string)
+            const returnData = this.getReturnDataFromResult(methodContext.result) as unknown as string;
+            
+            // Try fast path for simple types first (avoids expensive ABI decoder)
+            let decodedReturnValues: any[] | null = this.fastDecodeSimpleType(returnData, outputTypes);
+            
+            if (!decodedReturnValues) {
+              // Fall back to full ABI decoder for complex types
+              const decoded = defaultAbiCoder.decode(
+                // tslint:disable-next-line: no-any
+                outputTypes as any,
+                returnData
+              );
+              decodedReturnValues = this.formatReturnValues(decoded);
+            }
 
+<<<<<<< Updated upstream
             // No need to deepClone - this is a fresh object literal
             returnObjectResult.callsReturnContext.push({
               returnValues: this.formatReturnValues(decodedReturnValues),
+=======
+            // Place result at the correct index (not push) to maintain correspondence with calls array
+            returnObjectResult.callsReturnContext[callIndex] = {
+              returnValues: decodedReturnValues,
+>>>>>>> Stashed changes
               decoded: true,
               reference: originalContractCallMethodContext.reference,
               methodName: originalContractCallMethodContext.methodName,
@@ -363,6 +379,93 @@ export class Multicall {
     }
 
     return aggregateCallContext;
+  }
+
+  /**
+   * Fast decode for simple/common return types without full ABI decoder overhead.
+   * Returns null if the type is not supported for fast decoding.
+   * @param returnData The raw hex return data
+   * @param outputTypes The ABI output types
+   */
+  private fastDecodeSimpleType(
+    returnData: string,
+    outputTypes: AbiOutput[]
+  ): any[] | null {
+    // Only handle single output cases for now
+    if (outputTypes.length !== 1) return null;
+    
+    const type = outputTypes[0].type;
+    
+    // uint256/uint128/etc - most common case for balance calls
+    if (type === 'uint256' || type === 'uint128' || type === 'uint64' || 
+        type === 'uint32' || type === 'uint16' || type === 'uint8') {
+      try {
+        // Convert hex bytes to decimal string (matches ethers BigNumber.toString() behavior)
+        const bn = BigInt(returnData);
+        return [bn.toString(10)];
+      } catch {
+        return null; // Fall back to full decoder on error
+      }
+    }
+    
+    // int256/int128/etc - signed integers
+    if (type === 'int256' || type === 'int128' || type === 'int64' ||
+        type === 'int32' || type === 'int16' || type === 'int8') {
+      try {
+        // For signed integers, we need to handle two's complement
+        // Sign bit threshold and max value for each type
+        const signedBitInfo: Record<string, { signBit: bigint; maxVal: bigint }> = {
+          'int256': { signBit: 1n << 255n, maxVal: 1n << 256n },
+          'int128': { signBit: 1n << 127n, maxVal: 1n << 128n },
+          'int64':  { signBit: 1n << 63n,  maxVal: 1n << 64n },
+          'int32':  { signBit: 1n << 31n,  maxVal: 1n << 32n },
+          'int16':  { signBit: 1n << 15n,  maxVal: 1n << 16n },
+          'int8':   { signBit: 1n << 7n,   maxVal: 1n << 8n },
+        };
+        
+        const bn = BigInt(returnData);
+        const { signBit, maxVal } = signedBitInfo[type];
+        
+        // Mask to the correct bit width, then check sign bit
+        const masked = bn & (maxVal - 1n);
+        if (masked >= signBit) {
+          // Negative number in two's complement
+          return [(masked - maxVal).toString(10)];
+        }
+        return [masked.toString(10)];
+      } catch {
+        return null;
+      }
+    }
+    
+    // address type
+    if (type === 'address') {
+      try {
+        // Extract last 40 chars (20 bytes) from the 32-byte word
+        const addr = '0x' + returnData.slice(-40).toLowerCase();
+        return [addr];
+      } catch {
+        return null;
+      }
+    }
+    
+    // bool type
+    if (type === 'bool') {
+      try {
+        // Any non-zero value is true
+        return [returnData !== '0x' + '0'.repeat(64)];
+      } catch {
+        return null;
+      }
+    }
+    
+    // bytes32 type
+    if (type === 'bytes32') {
+      // Return as-is (already 32 bytes hex)
+      return [returnData];
+    }
+    
+    return null; // Fall back to full decoder for other types
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2020",
     "lib": ["es6", "dom", "es2016", "es2017"],
     "module": "esnext",
     "declaration": true,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how multicall results are indexed and decoded, which can affect return value ordering and types (notably BigNumber vs string) for consumers. Also raises the TS compile target to ES2020, which may impact downstream runtime compatibility.
> 
> **Overview**
> Fixes an ordering bug in `Multicall.call()` by pre-allocating `callsReturnContext` and writing results by `contractMethodIndex` instead of `push`, ensuring returned results align with the original `calls` array even when batching/merging.
> 
> Adds a fast-path decoder for common single-output types (`uint*`, `int*`, `address`, `bool`, `bytes32`) using `BigInt` to avoid full ABI decoding overhead, and normalizes ABI-decoded values (including converting `BigNumber` to decimal strings while preserving tuple/struct named keys) for more consistent outputs.
> 
> Bumps package version to `2.17.0` and updates `tsconfig` target to `ES2020`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce5f21833c8434fd33eaaf22094866cc104b5bd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->